### PR TITLE
feat: include width and height in info

### DIFF
--- a/src/DicomEcg.js
+++ b/src/DicomEcg.js
@@ -284,6 +284,9 @@ class DicomEcg {
       this._renderLeadTitle(svgWriter, waveform.leads[i], i, leadHeight);
     }
 
+    info.push({ key: 'Width', value: width });
+    info.push({ key: 'Height', value: height });
+
     return { svg: svgWriter.toXmlString(), info };
   }
 


### PR DESCRIPTION
Hi Pantelis :) 

Just a small PR suggesting we let the consumer of the library access the rendered width and height

Open to suggestions on better ways to expose this! But in the info seemed reasonable